### PR TITLE
fix: correct memory layout

### DIFF
--- a/examples/hifive-unmatched-a00.rs
+++ b/examples/hifive-unmatched-a00.rs
@@ -4,8 +4,6 @@ use alloc::collections::BTreeMap;
 use serde_derive::Deserialize;
 use serde_device_tree::Compatible;
 
-static DEVICE_TREE: &'static [u8] = include_bytes!("hifive-unmatched-a00.dtb");
-
 #[derive(Debug, Deserialize)]
 struct Tree<'a> {
     #[serde(rename = "#address-cells")]
@@ -48,8 +46,20 @@ struct Cpu<'a> {
     compatible: Compatible<'a>,
 }
 
+const RAW_DEVICE_TREE: &'static [u8] = include_bytes!("hifive-unmatched-a00.dtb");
+const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
+
+#[repr(align(4))]
+struct AlignedBuffer {
+    pub data: [u8; RAW_DEVICE_TREE.len()],
+}
+
 fn main() {
-    let ptr = DEVICE_TREE.as_ptr();
+    let mut aligned_data: Box<AlignedBuffer> = Box::new(AlignedBuffer {
+        data: [0; BUFFER_SIZE],
+    });
+    aligned_data.data[..BUFFER_SIZE].clone_from_slice(&RAW_DEVICE_TREE);
+    let ptr = aligned_data.data.as_ptr();
     let t: Tree = unsafe { serde_device_tree::from_raw(ptr) }.unwrap();
     println!("#address_cells = {}", t.num_address_cells);
     println!("#size_cells = {}", t.num_size_cells);

--- a/src/de.rs
+++ b/src/de.rs
@@ -60,6 +60,9 @@ where
     T: de::Deserialize<'de>,
 {
     // read header
+    if (ptr as usize) & (ALIGN - 1) != 0 {
+        return Err(Error::unaligned(ptr as usize));
+    }
     let header = &*(ptr as *const Header);
     header.verify()?;
 

--- a/src/de_mut/cursor.rs
+++ b/src/de_mut/cursor.rs
@@ -2,6 +2,7 @@
 use core::marker::PhantomData;
 
 #[derive(Clone, Copy, Debug)]
+#[repr(C)]
 pub(super) struct AnyCursor<T: Type = Body>(usize, PhantomData<T>);
 
 pub(super) type BodyCursor = AnyCursor<Body>;

--- a/src/de_mut/group.rs
+++ b/src/de_mut/group.rs
@@ -2,6 +2,7 @@
 use serde::de;
 
 #[allow(unused)]
+#[repr(C)]
 pub(super) struct GroupDeserializer<'de> {
     pub dtb: RefDtb<'de>,
     pub cursor: GroupCursor,

--- a/src/de_mut/node_seq.rs
+++ b/src/de_mut/node_seq.rs
@@ -7,6 +7,7 @@ use serde::{de, Deserialize};
 /// 在解析前，无法得知这种节点的数量，因此也无法为它们分配足够的空间，
 /// 因此这些节点将延迟解析。
 /// 迭代 `NodeSeq` 可获得一系列 [`NodeSeqItem`]，再调用 `deserialize` 方法分别解析每个节点。
+#[repr(C)]
 pub struct NodeSeq<'de> {
     dtb: RefDtb<'de>,
     cursor: GroupCursor,

--- a/src/de_mut/node_seq.rs
+++ b/src/de_mut/node_seq.rs
@@ -9,8 +9,8 @@ use serde::{de, Deserialize};
 /// 迭代 `NodeSeq` 可获得一系列 [`NodeSeqItem`]，再调用 `deserialize` 方法分别解析每个节点。
 pub struct NodeSeq<'de> {
     dtb: RefDtb<'de>,
-    reg: RegConfig,
     cursor: GroupCursor,
+    reg: RegConfig,
     len_item: usize,
     len_name: usize,
 }

--- a/src/de_mut/reg.rs
+++ b/src/de_mut/reg.rs
@@ -22,6 +22,7 @@ pub struct RegRegion(pub Range<usize>);
 
 /// 节点地址空间格式。
 #[derive(Clone, Copy, Debug)]
+#[repr(C)]
 pub(super) struct RegConfig {
     pub address_cells: u32,
     pub size_cells: u32,


### PR DESCRIPTION
由于 https://github.com/rustsbi/serde-device-tree/blob/main/src/de_mut/group.rs#L169 中会直接将 `GroupDeserializer<'_>` 拷贝给 `NodeSeq<'de>`，所以需要保证一致的内存布局。

同时，由于 https://github.com/rustsbi/serde-device-tree/blob/main/src/common.rs#L75 中调用的 `from_raw_parts` 要求 `properly aligned`，可能会导致 `hifive-unmatched-a00` 无法正常运行。