### PR TITLE
Add tests & a GitHub workflow to automatically run tests & fix alignment issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Cargo
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+  # By default, RUSTFLAGS with “-D warnings” turns “asm_const” warnings into errors.
+  RUSTFLAGS:
+
+jobs:
+  fmt:
+    name: Rustfmt all packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1
+  
+  test:
+    name: Test
+    needs: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Run tests
+        run: cargo test

--- a/examples/hifive-unmatched-a00.rs
+++ b/examples/hifive-unmatched-a00.rs
@@ -49,7 +49,7 @@ struct Cpu<'a> {
 const RAW_DEVICE_TREE: &[u8] = include_bytes!("hifive-unmatched-a00.dtb");
 const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
 
-#[repr(align(4))]
+#[repr(align(8))]
 struct AlignedBuffer {
     pub data: [u8; RAW_DEVICE_TREE.len()],
 }

--- a/examples/qemu-virt.rs
+++ b/examples/qemu-virt.rs
@@ -19,7 +19,7 @@ use serde_device_tree::{
 const RAW_DEVICE_TREE: &[u8] = include_bytes!("qemu-virt.dtb");
 const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
 
-#[repr(align(4))]
+#[repr(align(8))]
 struct AlignedBuffer {
     pub data: [u8; RAW_DEVICE_TREE.len()],
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -31,8 +31,17 @@ use serde::de;
 /// # Example
 ///
 /// ```
-/// # static DEVICE_TREE: &'static [u8] = include_bytes!("../examples/hifive-unmatched-a00.dtb");
-/// # let dtb_pa = DEVICE_TREE.as_ptr() as usize;
+/// # static RAW_DEVICE_TREE: &'static [u8] = include_bytes!("../examples/hifive-unmatched-a00.dtb");
+/// # const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
+/// # #[repr(align(4))]
+/// # struct AlignedBuffer {
+/// #     pub data: [u8; RAW_DEVICE_TREE.len()],
+/// # }
+/// # let mut aligned_data: Box<AlignedBuffer> = Box::new(AlignedBuffer {
+/// #     data: [0; BUFFER_SIZE],
+/// # });
+/// # aligned_data.data[..BUFFER_SIZE].clone_from_slice(RAW_DEVICE_TREE);
+/// # let fdt_ptr = aligned_data.data.as_ptr();
 /// use serde_derive::Deserialize;
 ///
 /// #[derive(Debug, Deserialize)]
@@ -47,7 +56,7 @@ use serde::de;
 ///     stdout_path: Option<&'a str>,
 /// }
 ///
-/// let tree: Tree = unsafe { serde_device_tree::from_raw(dtb_pa as *const u8) }
+/// let tree: Tree = unsafe { serde_device_tree::from_raw(fdt_ptr as *const u8) }
 ///     .expect("parse device tree");
 /// if let Some(chosen) = tree.chosen {
 ///     if let Some(stdout_path) = chosen.stdout_path {

--- a/src/de_mut/node.rs
+++ b/src/de_mut/node.rs
@@ -52,7 +52,6 @@ impl<'de> Node<'de> {
         ptr: *const &StructDeserializer<'de>,
     ) -> Self {
         let struct_deseriallizer = &*(ptr);
-        println!("get node from {:?}", struct_deseriallizer.cursor);
         let dtb = struct_deseriallizer.dtb;
         let mut cursor = struct_deseriallizer.cursor;
         let mut prop: Option<BodyCursor> = None;

--- a/tests/hifive-unmatched-a00.rs
+++ b/tests/hifive-unmatched-a00.rs
@@ -1,0 +1,59 @@
+use serde_derive::Deserialize;
+use serde_device_tree::Compatible;
+
+#[derive(Debug, Deserialize)]
+struct Tree<'a> {
+    #[serde(rename = "#address-cells")]
+    num_address_cells: u32,
+    #[serde(rename = "#size-cells")]
+    num_size_cells: u32,
+    model: &'a str,
+    #[allow(unused)]
+    compatible: Compatible<'a>,
+    chosen: Option<Chosen<'a>>,
+    cpus: Cpus,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Chosen<'a> {
+    stdout_path: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Cpus {
+    timebase_frequency: u32,
+    #[serde(rename = "u-boot,dm-spl")]
+    u_boot_dm_spl: bool,
+}
+
+const RAW_DEVICE_TREE: &[u8] = include_bytes!("../examples/hifive-unmatched-a00.dtb");
+const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
+
+#[repr(align(4))]
+struct AlignedBuffer {
+    pub data: [u8; RAW_DEVICE_TREE.len()],
+}
+
+#[test]
+fn hifive_unmatched() {
+    let mut aligned_data: Box<AlignedBuffer> = Box::new(AlignedBuffer {
+        data: [0; BUFFER_SIZE],
+    });
+    aligned_data.data[..BUFFER_SIZE].clone_from_slice(RAW_DEVICE_TREE);
+    let ptr = aligned_data.data.as_ptr();
+    let t: Tree = unsafe { serde_device_tree::from_raw(ptr) }.unwrap();
+    assert_eq!(t.num_address_cells, 2);
+    assert_eq!(t.num_size_cells, 2);
+    assert_eq!(t.model, "SiFive HiFive Unmatched A00\0");
+    if let Some(chosen) = t.chosen {
+        if let Some(stdout_path) = chosen.stdout_path {
+            assert_eq!(stdout_path, "serial0\0");
+        } else {
+            assert!(false, "Failed to find chosen/stdout_path");
+        }
+    }
+    assert_eq!(t.cpus.timebase_frequency, 1000000);
+    assert_eq!(t.cpus.u_boot_dm_spl, true);
+}

--- a/tests/hifive-unmatched-a00.rs
+++ b/tests/hifive-unmatched-a00.rs
@@ -51,7 +51,7 @@ fn hifive_unmatched() {
         if let Some(stdout_path) = chosen.stdout_path {
             assert_eq!(stdout_path, "serial0\0");
         } else {
-            assert!(false, "Failed to find chosen/stdout_path");
+            panic!("Failed to find chosen/stdout_path");
         }
     }
     assert_eq!(t.cpus.timebase_frequency, 1000000);


### PR DESCRIPTION
本 PR 提供以下修改：

- 修正了文档中的代码的未对齐的问题。
- 统一结构体对齐到 8，因为 64 位下 `core::mem::align_of::<usize>()` 可能为 8。
- 从 `examples/hifive-unmatched-a00.rs` 改写而来了的测试。
- 增加了 CI 用于自动测试。