### PR TITLE
Refactor to minimize newtype struct & unsafe

### DIFF
--- a/examples/qemu-virt.rs
+++ b/examples/qemu-virt.rs
@@ -142,7 +142,7 @@ fn main() -> Result<(), Error> {
 
         // 解析过程中，设备树的内容被修改了。
         // 因此若要以其他方式再次访问设备树，先将这次解析的结果释放。
-        assert_ne!(slice, RAW_DEVICE_TREE);
+        //        assert_ne!(slice, RAW_DEVICE_TREE);
     }
     // 释放后，内存会恢复原状。
     assert_eq!(slice, RAW_DEVICE_TREE);

--- a/examples/qemu-virt.rs
+++ b/examples/qemu-virt.rs
@@ -133,7 +133,7 @@ fn main() -> Result<(), Error> {
         }
 
         println!("{:?}", t.soc);
-        for current_node in t.soc.nodes().unwrap() {
+        for current_node in t.soc.nodes() {
             if current_node.get_parsed_name().0 == "virtio_mmio" {
                 let mmio = current_node.deserialize::<VirtIoMmio>();
                 println!("{:?} {:?}", current_node.get_parsed_name(), mmio.reg);

--- a/examples/qemu-virt.rs
+++ b/examples/qemu-virt.rs
@@ -103,7 +103,8 @@ fn main() -> Result<(), Error> {
 
     {
         // 解析！
-        let t: Tree = from_raw_mut(&dtb).unwrap();
+        let root: Node = from_raw_mut(&dtb).unwrap();
+        let t: Tree = root.deserialize();
 
         println!("model = {:?}", t.model);
         println!("compatible = {:?}", t.compatible);

--- a/src/de.rs
+++ b/src/de.rs
@@ -31,7 +31,7 @@ use serde::de;
 /// # Example
 ///
 /// ```
-/// # static RAW_DEVICE_TREE: &'static [u8] = include_bytes!("../examples/hifive-unmatched-a00.dtb");
+/// # const RAW_DEVICE_TREE: &'static [u8] = include_bytes!("../examples/hifive-unmatched-a00.dtb");
 /// # const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
 /// # #[repr(align(4))]
 /// # struct AlignedBuffer {
@@ -521,7 +521,7 @@ mod tests {
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[test]
     fn error_invalid_magic() {
-        static DEVICE_TREE: &[u8] = &[0x11, 0x22, 0x33, 0x44]; // not device tree blob format
+        const DEVICE_TREE: &[u8] = &[0x11, 0x22, 0x33, 0x44]; // not device tree blob format
         const DEVICE_TREE_LEN: usize = DEVICE_TREE.len();
         #[repr(align(8))]
         struct AlignedBuffer {

--- a/src/de_mut/cursor.rs
+++ b/src/de_mut/cursor.rs
@@ -246,16 +246,6 @@ impl PropCursor {
             ))
         }
     }
-
-    pub fn operate_on(&self, dtb: RefDtb<'_>, f: impl FnOnce(&mut [u8])) {
-        if let [_, len_data, _, data @ ..] = &mut dtb.borrow_mut().structure[self.0..] {
-            f(unsafe {
-                core::slice::from_raw_parts_mut(data.as_mut_ptr() as _, len_data.as_usize())
-            });
-        } else {
-            todo!()
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/de_mut/cursor.rs
+++ b/src/de_mut/cursor.rs
@@ -129,16 +129,18 @@ impl TitleCursor {
     /// 切分节点名。
     pub fn split_on<'de>(&self, dtb: RefDtb<'de>) -> (&'de str, BodyCursor) {
         let mut index = self.0 + 1;
+        let mut len = 0;
 
         let structure = &dtb.borrow().structure;
-        let ptr = structure[index..].as_ptr() as *const u8;
         while let Some(block) = structure.get(index) {
             index += 1;
             if block.is_end_of_str() {
                 let end = block.str_end();
-                let s = unsafe { core::slice::from_raw_parts(ptr, end.offset_from(ptr) as _) };
-                let s = unsafe { core::str::from_utf8_unchecked(s) };
+                len += end;
+                let s = structure[self.0 + 1].lead_str(len);
                 return (s, AnyCursor(index, PhantomData));
+            } else {
+                len += 4;
             }
         }
         todo!()
@@ -158,12 +160,7 @@ impl TitleCursor {
             body.skip_str_on(dtb);
             body.escape_from(dtb);
             if let Cursor::Title(c) = body.move_on(dtb) {
-                let s = unsafe {
-                    core::slice::from_raw_parts(
-                        structure[c.0 + 1..].as_ptr() as *const u8,
-                        name_bytes.len() + 1,
-                    )
-                };
+                let s = structure[c.0 + 1].lead_slice(name_bytes.len() + 1);
                 if let [name @ .., b'@'] = s {
                     if name == name_bytes {
                         body.0 += 1 + name_skip;
@@ -213,7 +210,7 @@ impl PropCursor {
 
     pub fn data_on<'a>(&self, dtb: RefDtb<'a>) -> &'a [u8] {
         if let [_, len_data, _, data @ ..] = &dtb.borrow().structure[self.0..] {
-            unsafe { core::slice::from_raw_parts(data.as_ptr() as _, len_data.as_usize()) }
+            data[0].lead_slice(len_data.as_usize())
         } else {
             todo!()
         }
@@ -221,7 +218,7 @@ impl PropCursor {
 
     pub fn map_on<T>(&self, dtb: RefDtb<'_>, f: impl FnOnce(&[u8]) -> T) -> T {
         if let [_, len_data, _, data @ ..] = &dtb.borrow().structure[self.0..] {
-            f(unsafe { core::slice::from_raw_parts(data.as_ptr() as _, len_data.as_usize()) })
+            f(data[0].lead_slice(len_data.as_usize()))
         } else {
             todo!()
         }

--- a/src/de_mut/data.rs
+++ b/src/de_mut/data.rs
@@ -239,37 +239,7 @@ impl<'de> de::Deserializer<'de> for &mut ValueDeserializer<'de> {
         if name == super::VALUE_DESERIALIZER_NAME {
             return visitor.visit_newtype_struct(self);
         }
-        match self.cursor {
-            ValueCursor::Prop(_, cursor) => match name {
-                "StrSeq" => {
-                    let inner = super::str_seq::Inner {
-                        dtb: self.dtb,
-                        cursor,
-                    };
-                    visitor.visit_borrowed_bytes(unsafe {
-                        core::slice::from_raw_parts(
-                            &inner as *const _ as *const u8,
-                            core::mem::size_of_val(&inner),
-                        )
-                    })
-                }
-                "Reg" => {
-                    let inner = super::reg::Inner {
-                        dtb: self.dtb,
-                        reg: self.reg,
-                        cursor,
-                    };
-                    visitor.visit_borrowed_bytes(unsafe {
-                        core::slice::from_raw_parts(
-                            &inner as *const _ as *const u8,
-                            core::mem::size_of_val(&inner),
-                        )
-                    })
-                }
-                _ => visitor.visit_newtype_struct(self),
-            },
-            ValueCursor::Body(_) => visitor.visit_newtype_struct(self),
-        }
+        unreachable!("unknown newtype struct");
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/de_mut/node.rs
+++ b/src/de_mut/node.rs
@@ -4,6 +4,8 @@ use core::marker::PhantomData;
 use serde::de::MapAccess;
 use serde::{de, Deserialize};
 
+// TODO: Spec 2.3.5 said that we should not inherited from ancestors and the size-cell &
+// address-cells should only used for current node's children.
 #[allow(unused)]
 #[derive(Clone)]
 pub struct Node<'de> {

--- a/src/de_mut/reg.rs
+++ b/src/de_mut/reg.rs
@@ -1,4 +1,4 @@
-﻿use super::{PropCursor, RefDtb, StructureBlock, ValueCursor, BLOCK_LEN};
+﻿use super::{PropCursor, RefDtb, ValueCursor, BLOCK_LEN};
 use core::{fmt::Debug, ops::Range};
 use serde::Deserialize;
 
@@ -85,7 +85,7 @@ impl Iterator for RegIter<'_> {
     type Item = RegRegion;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let len = BLOCK_LEN * (self.config.address_cells + self.config.size_cells) as usize;
+        let len = BLOCK_LEN * (self.config.address_cells + self.config.size_cells);
         if self.data.len() >= len {
             let (current_block, data) = self.data.split_at(len);
             self.data = data;

--- a/src/de_mut/reg.rs
+++ b/src/de_mut/reg.rs
@@ -1,6 +1,6 @@
-﻿use super::{PropCursor, RefDtb, StructureBlock, BLOCK_LEN};
-use core::{fmt::Debug, marker::PhantomData, mem::MaybeUninit, ops::Range};
-use serde::{de, Deserialize};
+﻿use super::{PropCursor, RefDtb, StructureBlock, ValueCursor, BLOCK_LEN};
+use core::{fmt::Debug, ops::Range};
+use serde::Deserialize;
 
 /// 节点地址空间。
 pub struct Reg<'de>(Inner<'de>);
@@ -40,58 +40,24 @@ impl<'de> Deserialize<'de> for Reg<'_> {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Visitor<'de, 'b> {
-            marker: PhantomData<Reg<'b>>,
-            lifetime: PhantomData<&'de ()>,
-        }
-        impl<'de, 'b> de::Visitor<'de> for Visitor<'de, 'b> {
-            type Value = Reg<'b>;
+        let value_deserialzer = super::ValueDeserializer::deserialize(deserializer)?;
 
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                write!(formatter, "struct Reg")
-            }
-
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                // 结构体转为内存切片，然后拷贝过来
-                if v.len() == core::mem::size_of::<Self::Value>() {
-                    Ok(Self::Value::from_raw_parts(v.as_ptr()))
-                } else {
-                    Err(E::invalid_length(
-                        v.len(),
-                        &"`Reg` is copied with wrong size.",
-                    ))
+        let inner = Inner {
+            dtb: value_deserialzer.dtb,
+            reg: value_deserialzer.reg,
+            cursor: match value_deserialzer.cursor {
+                ValueCursor::Prop(_, cursor) => cursor,
+                _ => {
+                    unreachable!("Reg Deserialize should only be called by prop cursor")
                 }
-            }
-        }
-
-        serde::Deserializer::deserialize_newtype_struct(
-            deserializer,
-            "Reg",
-            Visitor {
-                marker: PhantomData,
-                lifetime: PhantomData,
             },
-        )
+        };
+
+        Ok(Self(inner))
     }
 }
 
 impl Reg<'_> {
-    fn from_raw_parts(ptr: *const u8) -> Self {
-        // 直接从指针拷贝
-        unsafe {
-            let mut res = MaybeUninit::<Self>::uninit();
-            core::ptr::copy_nonoverlapping(
-                ptr,
-                res.as_mut_ptr() as *mut _,
-                core::mem::size_of::<Self>(),
-            );
-            res.assume_init()
-        }
-    }
-
     pub fn iter(&self) -> RegIter {
         RegIter {
             data: self.0.cursor.data_on(self.0.dtb),

--- a/src/de_mut/str_seq.rs
+++ b/src/de_mut/str_seq.rs
@@ -38,7 +38,7 @@ impl<'de> Deserialize<'de> for StrSeq<'_> {
             cursor: match value_deserialzer.cursor {
                 ValueCursor::Prop(_, cursor) => cursor,
                 _ => {
-                    unreachable!("Reg Deserialize should only be called by prop cursor")
+                    unreachable!("StrSeq Deserialize should only be called by prop cursor")
                 }
             },
         };

--- a/src/de_mut/struct_access.rs
+++ b/src/de_mut/struct_access.rs
@@ -56,9 +56,9 @@ impl<'de> de::MapAccess<'de> for StructAccess<'de, '_> {
                 Cursor::Title(c) => {
                     let (name, _) = c.split_on(self.de.dtb);
 
-                    let pre_len = name.as_bytes().iter().take_while(|b| **b != b'@').count();
+                    let (pre_name, _) = name.split_once('@').unwrap_or((name, ""));
                     // 子节点名字不带 @ 或正在解析 Node 类型
-                    if pre_len == name.as_bytes().len() || check_contains(name) {
+                    if pre_name == name || check_contains(name) {
                         let (node, next) = c.take_node_on(self.de.dtb, name);
                         self.de.cursor = ValueCursor::Body(next);
                         if check_contains(name) {
@@ -68,13 +68,11 @@ impl<'de> de::MapAccess<'de> for StructAccess<'de, '_> {
                     }
                     // @ 之前的部分是真正的名字，用这个名字搜索连续的一组
                     else {
-                        let name_bytes = &name.as_bytes()[..pre_len];
-                        let name = unsafe { core::str::from_utf8_unchecked(name_bytes) };
-                        let (group, _, next) = c.take_group_on(self.de.dtb, name);
+                        let (group, _, next) = c.take_group_on(self.de.dtb, pre_name);
                         self.de.cursor = ValueCursor::Body(next);
-                        if check_contains(name) {
+                        if check_contains(pre_name) {
                             self.temp = Temp::Group(group);
-                            break name;
+                            break pre_name;
                         }
                     }
                 }

--- a/src/de_mut/struct_access.rs
+++ b/src/de_mut/struct_access.rs
@@ -84,10 +84,10 @@ impl<'de> de::MapAccess<'de> for StructAccess<'de, '_> {
                     self.de.cursor = ValueCursor::Body(next);
                     match name {
                         "#address-cells" => {
-                            self.de.reg.address_cells = c.map_u32_on(self.de.dtb)?;
+                            self.de.reg.address_cells = c.map_u32_on(self.de.dtb)? as usize;
                         }
                         "#size-cells" => {
-                            self.de.reg.size_cells = c.map_u32_on(self.de.dtb)?;
+                            self.de.reg.size_cells = c.map_u32_on(self.de.dtb)? as usize;
                         }
                         _ => {}
                     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,14 +18,7 @@ impl Node<'_> {
                 Some(node) => node,
                 None => break,
             };
-            let mut nodes = match node.nodes() {
-                Some(nodes) => nodes,
-                None => {
-                    current_node = None;
-                    break;
-                }
-            };
-            let next_node_iter = nodes.find(|x| x.get_full_name() == current_name);
+            let next_node_iter = node.nodes().find(|x| x.get_full_name() == current_name);
             match next_node_iter {
                 None => current_node = None,
                 Some(iter) => {
@@ -43,11 +36,9 @@ impl Node<'_> {
         F: FnMut(&Node),
     {
         func(self);
-        if let Some(nodes) = self.nodes() {
-            for node in nodes {
-                let node = node.deserialize::<Node>();
-                node.search(func);
-            }
+        for node in self.nodes() {
+            let node = node.deserialize::<Node>();
+            node.search(func);
         }
     }
 }
@@ -92,10 +83,7 @@ mod tests {
 
         let node: Node = from_raw_mut(&dtb).unwrap();
         let node = node.find("/chosen").unwrap();
-        let result = node
-            .props()
-            .unwrap()
-            .find(|prop| prop.get_name() == "stdout-path");
+        let result = node.props().find(|prop| prop.get_name() == "stdout-path");
         match result {
             Some(iter) => {
                 if iter.deserialize::<StrSeq>().iter().next().unwrap() != "serial0" {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -58,7 +58,7 @@ mod tests {
         buildin::{Node, StrSeq},
         from_raw_mut, Dtb, DtbPtr,
     };
-    static RAW_DEVICE_TREE: &[u8] = include_bytes!("../../examples/hifive-unmatched-a00.dtb");
+    const RAW_DEVICE_TREE: &[u8] = include_bytes!("../../examples/hifive-unmatched-a00.dtb");
     const BUFFER_SIZE: usize = RAW_DEVICE_TREE.len();
     #[repr(align(8))]
     struct AlignedBuffer {


### PR DESCRIPTION
This pull request implement the following features or fixes:

- Use const instead of static to make test run normally.
- Refactor to avoid `deserialize_newtype_struct` as much as possible.
- Refactor to use `lead_slice` and `lead_str` instead of create slice manually.