### PR TITLE
fix: can not add a new node / prop

### DIFF
--- a/examples/re_encode.rs
+++ b/examples/re_encode.rs
@@ -1,3 +1,4 @@
+use serde_device_tree::ser::{patch::Patch, serializer::ValueType};
 use serde_device_tree::{Dtb, DtbPtr, buildin::Node, error::Error, from_raw_mut};
 
 use std::io::prelude::*;
@@ -21,7 +22,8 @@ fn main() -> Result<(), Error> {
     let dtb = Dtb::from(ptr).share();
 
     let root: Node = from_raw_mut(&dtb).unwrap();
-    serde_device_tree::ser::to_dtb(&root, &[], &mut buf).unwrap();
+    let patch: Patch = Patch::new("/chosen/a", &"1", ValueType::Prop);
+    serde_device_tree::ser::to_dtb(&root, &[patch], &mut buf).unwrap();
 
     let mut file = std::fs::File::create("gen.dtb").unwrap();
     file.write_all(&buf).unwrap();

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 use std::io::prelude::*;
 
+use serde_device_tree::ser::serializer::ValueType;
+
 const MAX_SIZE: usize = 256 + 32;
 
 fn main() {
@@ -19,7 +21,8 @@ fn main() {
 
     {
         let new_base = Base1 { hello: "added" };
-        let patch = serde_device_tree::ser::patch::Patch::new("/base3", &new_base as _);
+        let patch =
+            serde_device_tree::ser::patch::Patch::new("/base3", &new_base as _, ValueType::Node);
         let list = [patch];
         let base = Base {
             hello: 0xdeedbeef,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -25,8 +25,9 @@ where
         let mut patch_list = crate::ser::patch::PatchList::new(list);
         let mut block = crate::ser::string_block::StringBlock::new(writer, &mut offset);
         let mut ser =
-            crate::ser::serializer::Serializer::new(&mut dst, &mut block, &mut patch_list);
-        data.serialize(&mut ser)?;
+            crate::ser::serializer::SerializerInner::new(&mut dst, &mut block, &mut patch_list);
+        let ser = crate::ser::serializer::Serializer::new(&mut ser);
+        data.serialize(ser)?;
     };
     list.iter().for_each(|patch| patch.init());
     // Write from bottom to top, to avoid overlap.
@@ -44,11 +45,11 @@ where
         let mut block = crate::ser::string_block::StringBlock::new(string_block, &mut offset);
         let mut dst = crate::ser::pointer::Pointer::new(Some(data_block));
         let mut ser =
-            crate::ser::serializer::Serializer::new(&mut dst, &mut block, &mut patch_list);
-        data.serialize(&mut ser)?;
-        ser.dst.step_by_u32(FDT_END);
-        ser.dst.get_offset()
-    };
+            crate::ser::serializer::SerializerInner::new(&mut dst, &mut block, &mut patch_list);
+        let ser = crate::ser::serializer::Serializer::new(&mut ser);
+        data.serialize(ser)?
+    }
+    .1;
     // Make header
     {
         let header = unsafe { &mut *(header.as_mut_ptr() as *mut Header) };

--- a/src/ser/pointer.rs
+++ b/src/ser/pointer.rs
@@ -31,10 +31,12 @@ impl<'se> Pointer<'se> {
         }
     }
 
+    /// Create a PROP header with nop padding, return the offset of `FDT_PROP` token.
     #[inline(always)]
     pub fn step_by_prop(&mut self) -> usize {
         self.step_by_u32(FDT_PROP);
         let offset = self.offset;
+        // Put 2 nop as `name` and `nameoff`.
         self.step_by_u32(FDT_NOP); // When create prop header, we do not know how long of the prop value.
         self.step_by_u32(FDT_NOP); // We can not assume this is a prop, so nop for default.
         offset


### PR DESCRIPTION
- fix: can not add a new node / prop
- refactor: serialize and patch

---

To avoid copy-paste word, we use SerializeMap instead of `serialize_newtype_struct`.This change required rewrite `serialize_dynamic_field` function and split it, so we can not use backtracking. 

Now it will create a new serailizer for every node or prop, not a ref.