### PR TITLE
fix: wrong level set when serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-dyn_serde = { version = "1.0.2", default-features = false, optional = true }
+dyn_serde = { version = "=1.1.2", default-features = false, optional = true }
 
 [features]
 default = ["std", "ser"]

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -17,13 +17,38 @@ fn main() {
     struct Base1 {
         pub hello: &'static str,
     }
+    #[derive(Serialize)]
+    struct ReversedMemory {
+        #[serde(rename = "#address-cells")]
+        pub address_cell: u32,
+        #[serde(rename = "#size-cells")]
+        pub size_cell: u32,
+        pub ranges: (),
+    }
+    #[derive(Serialize)]
+    struct ReversedMemoryItem {
+        pub reg: [u32; 4],
+    }
     let mut buf1 = [0u8; MAX_SIZE];
 
     {
-        let new_base = Base1 { hello: "added" };
-        let patch =
-            serde_device_tree::ser::patch::Patch::new("/base3", &new_base as _, ValueType::Node);
-        let list = [patch];
+        let new_base = ReversedMemory {
+            address_cell: 2,
+            size_cell: 2,
+            ranges: (),
+        };
+        let new_base_2 = ReversedMemoryItem { reg: [0, 1, 0, 20] };
+        let patch1 = serde_device_tree::ser::patch::Patch::new(
+            "/reversed-memory",
+            &new_base as _,
+            ValueType::Node,
+        );
+        let patch2 = serde_device_tree::ser::patch::Patch::new(
+            "/reversed-memory/mmode_resv1@0",
+            &new_base_2 as _,
+            ValueType::Node,
+        );
+        let list = [patch1, patch2];
         let base = Base {
             hello: 0xdeedbeef,
             base1: Base1 {

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 
 use serde_device_tree::ser::serializer::ValueType;
 
-const MAX_SIZE: usize = 256 + 32;
+const MAX_SIZE: usize = 1024;
 
 fn main() {
     #[derive(Serialize)]

--- a/src/de.rs
+++ b/src/de.rs
@@ -97,7 +97,7 @@ struct DeviceTree {
 }
 
 impl DeviceTree {
-    pub fn tags(&self) -> Tags {
+    pub fn tags(&self) -> Tags<'_> {
         let structure_addr = (u32::from_be(self.header.off_dt_struct) - HEADER_LEN) as usize;
         let structure_len = u32::from_be(self.header.size_dt_struct) as usize;
         let strings_addr = (u32::from_be(self.header.off_dt_strings) - HEADER_LEN) as usize;

--- a/src/de_mut/reg.rs
+++ b/src/de_mut/reg.rs
@@ -58,7 +58,7 @@ impl<'de> Deserialize<'de> for Reg<'_> {
 }
 
 impl Reg<'_> {
-    pub fn iter(&self) -> RegIter {
+    pub fn iter(&self) -> RegIter<'_> {
         RegIter {
             data: self.0.cursor.data_on(self.0.dtb),
             config: self.0.reg,

--- a/src/ser/patch.rs
+++ b/src/ser/patch.rs
@@ -56,7 +56,7 @@ impl<'se> Patch<'se> {
 
     #[inline(always)]
     pub fn get_depth_path(&self, x: usize) -> &'se str {
-        self.name.split('/').nth(x - 1).unwrap_or_default()
+        self.name.split('/').nth(x).unwrap_or_default()
     }
 
     // I hope to impl serde::ser::Serializer, but erase_serialize's return value is different from
@@ -66,7 +66,7 @@ impl<'se> Patch<'se> {
     pub fn serialize(&self, serializer: Serializer<'_, 'se>) {
         self.parsed.set(true);
         self.data
-            .serialize_dyn(&mut <dyn dyn_serde::Serializer>::new(serializer))
+            .dyn_serialize(&mut <dyn dyn_serde::Serializer>::new(serializer))
             .unwrap();
     }
 }

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -426,7 +426,7 @@ impl<'se> serde::ser::Serializer for Serializer<'_, 'se> {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        todo!("unit");
+        Ok((ValueType::Prop, self.ser.dst.get_offset()))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -70,10 +70,32 @@ impl<'a, 'se> Serializer<'a, 'se> {
     }
 
     #[inline(always)]
+    pub fn get_origin(self) -> Serializer<'a, 'se> {
+        Serializer {
+            ser: self.ser,
+            current_dep: self.current_dep,
+            current_name: self.current_name,
+            prop_token_offset: 0,
+            overwrite_patch: None,
+        }
+    }
+
+    #[inline(always)]
     pub fn get_next_ref<'b>(&'b mut self) -> Serializer<'b, 'se> {
         Serializer {
             ser: self.ser,
             current_dep: self.current_dep + 1,
+            current_name: self.current_name,
+            prop_token_offset: 0,
+            overwrite_patch: None,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_origin_ref<'b>(&'b mut self) -> Serializer<'b, 'se> {
+        Serializer {
+            ser: self.ser,
+            current_dep: self.current_dep,
             current_name: self.current_name,
             prop_token_offset: 0,
             overwrite_patch: None,
@@ -96,7 +118,7 @@ trait SerializeDynamicField<'se> {
 impl<'se> SerializeDynamicField<'se> for Serializer<'_, 'se> {
     fn start_node(&mut self) -> Result<(), Error> {
         self.ser.dst.step_by_u32(FDT_BEGIN_NODE);
-        if self.current_dep == 1 {
+        if self.current_dep == 0 {
             // The name of root node should be empty.
             self.ser.dst.step_by_u32(0);
         } else {
@@ -109,10 +131,11 @@ impl<'se> SerializeDynamicField<'se> for Serializer<'_, 'se> {
     fn end_node(&mut self) -> Result<(), Error> {
         for patch in self.ser.patch_list.add_list(self.current_dep) {
             let key = patch.get_depth_path(self.current_dep + 1);
-            self.serialize_dynamic_field(key, patch.data)?;
+            let mut ser = self.get_next_ref();
+            ser.serialize_dynamic_field(key, patch.data)?;
         }
         self.ser.dst.step_by_u32(FDT_END_NODE);
-        if self.current_dep == 1 {
+        if self.current_dep == 0 {
             self.ser.dst.step_by_u32(FDT_END);
         }
 
@@ -131,12 +154,12 @@ impl<'se> SerializeDynamicField<'se> for Serializer<'_, 'se> {
     {
         let value_type = match self.overwrite_patch {
             Some(data) => {
-                let ser = self.get_next_ref();
+                let ser = self.get_origin_ref();
                 data.serialize(ser);
                 data.patch_type
             }
             None => {
-                let ser = self.get_next_ref();
+                let ser = self.get_origin_ref();
                 value.serialize(ser)?.0
             }
         };
@@ -259,7 +282,7 @@ impl serde::ser::SerializeSeq for Serializer<'_, '_> {
     where
         T: ?Sized + serde::ser::Serialize,
     {
-        value.serialize(self.get_next_ref())?;
+        value.serialize(self.get_origin_ref())?;
         Ok(())
     }
 
@@ -277,7 +300,7 @@ impl serde::ser::SerializeTuple for Serializer<'_, '_> {
     where
         T: ?Sized + serde::ser::Serialize,
     {
-        value.serialize(self.get_next_ref())?;
+        value.serialize(self.get_origin_ref())?;
         Ok(())
     }
 
@@ -475,7 +498,7 @@ impl<'se> serde::ser::Serializer for Serializer<'_, 'se> {
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        let mut ser = self.get_next();
+        let mut ser = self.get_origin();
         ser.start_node()?;
         Ok(ser)
     }
@@ -485,7 +508,7 @@ impl<'se> serde::ser::Serializer for Serializer<'_, 'se> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        let mut ser = self.get_next();
+        let mut ser = self.get_origin();
         ser.start_node()?;
         Ok(ser)
     }


### PR DESCRIPTION
Previously, depth was incorrectly incremented, causing the Patch function to not work as expected. 

This pull request resolves the bug by ensuring that depth is only increased when a new key-value pair is serialized.